### PR TITLE
fix the following bug related to the update of package hmmlearn

### DIFF
--- a/prediction.py
+++ b/prediction.py
@@ -90,7 +90,7 @@ def to_viterbi_cents(salience, vecSize=486, smoothing_factor=12, modelTag=993):
                 ((1 - self_emission) / vecSize))
 
     # fix the model parameters because we are not optimizing the model
-    model = hmm.MultinomialHMM(vecSize, starting, transition)
+    model = hmm.CategoricalHMM(vecSize, starting, transition)
     model.startprob_, model.transmat_, model.emissionprob_ = \
         starting, transition, emission
 


### PR DESCRIPTION
Dear authors, first of all, I'd like to thank you for this wonderful code.

It seems the --viterbi option produces execution errors when used with the latest versions of hmmlearn package (hmmlearn==0.2.8).

CREPE implementation had similar problems which were fixed with a similar strategy : 
https://github.com/marl/crepe/commit/abea74287ae30a1ed630ba7e7b2eea188b306bfb

I would suggest to either merge this pull request, or update the readme to use older versions of hmmlearn (0.2.0)

Kind regards,
